### PR TITLE
Fixing  ruby 4 errors

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,8 @@ RedmineApp::Application.routes.draw do
 #  map.connect 'projects/:project_id/meetings/:action', :controller => 'meetings'
 #  map.connect 'meetings/:action/:id', :controller => 'meetings'
 #  map.connect 'projects/:id/meetings_settings/:action', :controller => 'meetings_settings'
-  match 'projects/:project_id/meetings/:action', :controller => 'meetings'
-  match 'meetings/:action/:id', :controller => 'meetings'
-  match 'projects/:id/meetings_settings/:action', :controller => 'meetings_settings'
+  match 'projects/:project_id/meetings/:action', :via => [:get], :controller => 'meetings'
+  match 'meetings/:action/:id', :via => [:get], :controller => 'meetings'
+  match 'projects/:id/meetings_settings/:action', :via => [:get], :controller => 'meetings_settings'
 
 end


### PR DESCRIPTION
Fixing errors like "should not use the `match` method in your router without specifying an HTTP method."
And adding compatibility with redmine 3.4.4